### PR TITLE
Fixed build errors and addressed PR feedback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 2.8.3)
 project(respeaker_ros)
 
 find_package(catkin REQUIRED COMPONENTS
-  catkin_virtualenv
   dynamic_reconfigure)
 if ($ENV{ROS_PYTHON_VERSION} EQUAL 2)
   find_package(catkin_virtualenv REQUIRED)
@@ -35,6 +34,10 @@ install(FILES requirements.txt
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 if (CATKIN_ENABLE_TESTING)
-  catkin_add_nosetests(test/test_installed.py
-    DEPENDENCIES ${PROJECT_NAME}_generate_virtualenv)
+  if ($ENV{ROS_PYTHON_VERSION} EQUAL 2)
+    catkin_add_nosetests(test/test_installed.py
+      DEPENDENCIES ${PROJECT_NAME}_generate_virtualenv)
+  else()
+    catkin_add_nosetests(test/test_installed.py)
+  endif()
 endif()

--- a/launch/respeaker.launch
+++ b/launch/respeaker.launch
@@ -1,15 +1,26 @@
 <launch>
+  <!-- publish tf of respeaker -->
+  <arg name="publish_tf" default="true"/>
+  <!-- launch sound_play node -->
+  <arg name="launch_soundplay" default="true"/>
+  <!-- langage used in speech_to_text.py -->
+  <arg name="language" default="en-US"/>
+  <!-- self_cancellation means halting speech_to_text while the robot is playing sound -->
+  <arg name="self_cancellation" default="true"/>
+
+  <node if="$(arg publish_tf)" name="static_transformer" pkg="tf" type="static_transform_publisher"
+        args="0 0 0 0 0 0 map respeaker_base 100"/>
+
   <node name="respeaker_node" pkg="respeaker_ros" type="respeaker_node.py"
 	output="screen"/>
 
-  <node name="static_transformer" pkg="tf" type="static_transform_publisher"
-        args="0 0 0 0 0 0 map respeaker_base 100"/>
+  <node if="$(arg launch_soundplay)"
+        name="sound_play" pkg="sound_play" type="soundplay_node.py"/>
 
   <node name="speech_to_text" pkg="respeaker_ros" type="speech_to_text.py">
-    <remap from="audio" to="speech_audio"/>
     <rosparam>
-      language: en-US
-      self_cancellation: true
+      language: $(arg language)
+      self_cancellation: $(arg self_cancellation)
       tts_tolerance: 0.5
     </rosparam>
   </node>

--- a/package.xml
+++ b/package.xml
@@ -8,7 +8,7 @@
   <author email="furushchev@jsk.imi.i.u-tokyo.ac.jp">Yuki Furuta</author>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <depend condition="$ROS_PYTHON_VERSION == 3">catkin_virtualenv</depend>
+  <depend condition="$ROS_PYTHON_VERSION == 2">catkin_virtualenv</depend>
   <depend>angles</depend>
   <depend>audio_common_msgs</depend>
   <depend>audio_play</depend>
@@ -16,7 +16,7 @@
   <depend>dynamic_reconfigure</depend>
   <depend>geometry_msgs</depend>
   <depend>portaudio19-dev</depend>
-  <depend>python-pyaudio</depend>
+  <depend>python3-pyaudio</depend>
   <depend>speech_recognition_msgs</depend>
   <depend>std_msgs</depend>
   <depend>tf</depend>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 PyAudio==0.2.8
 SpeechRecognition==3.8.1
 click==6.7
+numpy==1.16.2
 pixel-ring==0.1.0
 pyusb==1.0.2

--- a/scripts/speech_to_text.py
+++ b/scripts/speech_to_text.py
@@ -60,7 +60,7 @@ class SpeechToText(object):
                 self.last_tts = stamp
             if stamp - self.last_tts > self.tts_tolerance:
                 rospy.logdebug("END CANCELLATION")
-                self.is_canceling = Falser
+                self.is_canceling = False
 
     def audio_cb(self, msg):
         if self.is_canceling:
@@ -70,13 +70,12 @@ class SpeechToText(object):
 
         try:
             rospy.loginfo("Waiting for result %d" % len(data.get_raw_data()))
-            result = self.recognizer.recognize_sphinx(
+            result = self.recognizer.recognize_google(
                 data, language=self.language, show_all=False) #, key=None
             rospy.loginfo(result)
 
             msg = SpeechRecognitionCandidates(transcript=result)
             self.pub_speech.publish(msg)
-
         except SR.UnknownValueError as e:
             rospy.logerr("Failed to recognize: %s" % str(e))
             rospy.loginfo("value error")

--- a/scripts/speech_to_text.py
+++ b/scripts/speech_to_text.py
@@ -70,11 +70,10 @@ class SpeechToText(object):
 
         try:
             rospy.loginfo("Waiting for result %d" % len(data.get_raw_data()))
-            result = self.recognizer.recognize_google(
-                data, language=self.language, show_all=False) #, key=None
-            rospy.loginfo(result)
+            result, confidence = self.recognizer.recognize_google(
+                data, language=self.language, show_all=False, with_confidence=True)
 
-            msg = SpeechRecognitionCandidates(transcript=result)
+            msg = SpeechRecognitionCandidates(transcript=[result], confidence=[confidence])
             self.pub_speech.publish(msg)
         except SR.UnknownValueError as e:
             rospy.logerr("Failed to recognize: %s" % str(e))


### PR DESCRIPTION
This PR fixes catkin_virtualenv related build errors when attempting to use `catkin_make` on an Ubuntu 20.04 ROS Noetic workspace. Additionally, it addresses feedback left in @zacharykratochvil's [original PR](https://github.com/furushchev/respeaker_ros/pull/31) to https://github.com/furushchev/respeaker_ros. Finally, it makes a few tweaks, including:

 - Adding ROS args and the `sound_play` node to the `respeaker.launch`
 - Adding respeaker exception checks during initialization
 - Include confidence from the Google Speech API in the `/speech_to_text` topic.